### PR TITLE
Skip taint tests when -DSILENT_NO_TAINT_SUPPORT is enabled.

### DIFF
--- a/t/taint.t
+++ b/t/taint.t
@@ -4,18 +4,22 @@
 use strict;
 use warnings;
 
+use Config;
+
 BEGIN {
     if ( $ENV{PERL_CORE} ) {
-        require Config;
         no warnings 'once';
-        if ($Config::Config{extensions} !~ /\bList\/Util\b/) {
+        if ($Config{extensions} !~ /\bList\/Util\b/) {
             print "1..0 # Skip: Scalar::Util was not built\n";
             exit 0;
         }
-        if (exists($Config::Config{taint_support}) && not $Config::Config{taint_support}) {
-            print "1..0 # Skip: your perl was built without taint support\n";
-            exit 0;
-        }
+    }
+    if (
+        (exists($Config{taint_support}) && not $Config{taint_support}) ||
+        $Config{ccflags} =~ /-DSILENT_NO_TAINT_SUPPORT/
+    ) {
+        print "1..0 # Skip: your perl was built without taint support\n";
+        exit 0;
     }
 }
 


### PR DESCRIPTION
If perl is built with -DSILENT_NO_TAINT_SUPPORT checking `$Config{taint_support}` isn't enough, this adds a check that looks for -DSILENT_NO_TAINT_SUPPORT in `$Config{ccflags}`.