### PR TITLE
fix typo in module documentation

### DIFF
--- a/lib/Text/ParseWords.pm
+++ b/lib/Text/ParseWords.pm
@@ -202,7 +202,7 @@ functions simply call C<parse_line()>, so if you're only splitting
 one line you can call C<parse_line()> directly and save a function
 call.
 
-The C<$keep> controls what happens with delimters and special characters:
+The C<$keep> controls what happens with delimiters and special characters:
 
 =over 4
 


### PR DESCRIPTION
(Originally reported by Igor Sobrado Delgado on p5p.)